### PR TITLE
Fix broken test suite

### DIFF
--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -7,4 +7,12 @@ module.exports = {
       ],
     },
   },
+  jest: {
+    configure: {
+      moduleNameMapper: {
+        '^react-router-dom$': '<rootDir>/node_modules/react-router-dom/dist/index.js',
+        '^react-router/dom$': '<rootDir>/node_modules/react-router/dist/development/dom-export.js',
+      },
+    },
+  },
 }

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders welcome message', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/Welcome to the Home Page/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
The existing test suite was failing due to a combination of outdated configurations and environment issues. This change addresses these problems to make the tests pass.

The following fixes were implemented:
- Updated the Jest configuration in `craco.config.js` to correctly resolve `react-router-dom` and its dependencies. This was necessary due to incompatibilities between the old test runner and the modern module structure of the router library.
- Polyfilled `TextEncoder` and `TextDecoder` in `setupTests.js`. These browser APIs are used by `react-router` but are not available in the default Jest/JSDOM test environment.
- Updated the test case in `App.test.js` to assert for the correct content, as the default Create React App template test was outdated.